### PR TITLE
Add default date/time/weather widget

### DIFF
--- a/frontend/src/components/DefaultWidget.jsx
+++ b/frontend/src/components/DefaultWidget.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import Widget from './Widget';
+import axios from 'axios';
+
+const latitude = 35.85;  // Coordinates for zip 37130 (Murfreesboro, TN)
+const longitude = -86.39;
+
+function DefaultWidget({ id, onRemove }) {
+  const [weather, setWeather] = useState(null);
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    const fetchWeather = async () => {
+      try {
+        const res = await axios.get('https://api.open-meteo.com/v1/forecast', {
+          params: {
+            latitude,
+            longitude,
+            current_weather: true,
+            temperature_unit: 'fahrenheit'
+          }
+        });
+        if (res.data && res.data.current_weather) {
+          setWeather(res.data.current_weather);
+        }
+      } catch (e) {
+        console.error('Failed to fetch weather', e);
+      }
+    };
+    fetchWeather();
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <Widget id={id} onRemove={onRemove}>
+      <h3>{now.toLocaleDateString()}</h3>
+      <h4>{now.toLocaleTimeString()}</h4>
+      {weather ? (
+        <p>{`Temp: ${weather.temperature}°F, Wind ${weather.windspeed} mph`}</p>
+      ) : (
+        <p>Loading weather...</p>
+      )}
+    </Widget>
+  );
+}
+
+export default DefaultWidget;

--- a/frontend/src/components/Widget.jsx
+++ b/frontend/src/components/Widget.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Paper, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
-function Widget({ id, onRemove }) {
+function Widget({ id, onRemove, children }) {
   return (
     <Paper sx={{ p: 2, position: 'relative' }}>
       <IconButton onClick={() => onRemove(id)} sx={{ position: 'absolute', top: 0, right: 0 }}>
         <CloseIcon />
       </IconButton>
-      <p>Widget content {id}</p>
+      {children ? children : <p>Widget content {id}</p>}
     </Paper>
   );
 }

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Button, Container, Grid } from '@mui/material';
 import Widget from '../components/Widget';
+import DefaultWidget from '../components/DefaultWidget';
 
 function DashboardPage() {
-  const [widgets, setWidgets] = useState([]);
+  const [widgets, setWidgets] = useState([{ id: 'default', type: 'default' }]);
 
   const addWidget = () => {
-    setWidgets([...widgets, { id: Date.now() }]);
+    setWidgets([...widgets, { id: Date.now(), type: 'generic' }]);
   };
 
   const removeWidget = (id) => {
@@ -19,7 +20,11 @@ function DashboardPage() {
       <Grid container spacing={2}>
         {widgets.map(w => (
           <Grid item key={w.id} xs={12} md={6} lg={4}>
-            <Widget id={w.id} onRemove={removeWidget} />
+            {w.type === 'default' ? (
+              <DefaultWidget id={w.id} onRemove={removeWidget} />
+            ) : (
+              <Widget id={w.id} onRemove={removeWidget} />
+            )}
           </Grid>
         ))}
       </Grid>


### PR DESCRIPTION
## Summary
- show content in `Widget` via children to allow custom widgets
- implement `DefaultWidget` that displays the current date, time and weather for the 37130 zip code
- load `DefaultWidget` on the dashboard by default

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad08ab1b08331bf6e15bb7dd1a66e