### PR TITLE
Add MUI date pickers dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.15.0",
+        "@mui/x-date-pickers": "^6.0.0",
         "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.15.0",
+    "@mui/x-date-pickers": "^6.0.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "axios": "^1.4.0",


### PR DESCRIPTION
## Summary
- add `@mui/x-date-pickers` dependency required by `PlannerPanel`

## Testing
- `npm install --ignore-scripts` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae4b78e288331a454008209578fb8